### PR TITLE
Added check to ignore rndbots that are on a player's friend list

### DIFF
--- a/conf/mod_player_bot_level_brackets.conf.dist
+++ b/conf/mod_player_bot_level_brackets.conf.dist
@@ -53,6 +53,13 @@ BotLevelBrackets.UseDynamicDistribution = 0
 BotLevelBrackets.RealPlayerWeight = 1.0
 
 #
+#	BotLevelBrackets.IgnoreFriendListed
+#		 Description: Ignore bots that are on real players friend's lists from any brackets
+#		 Default:	  1 (enabled)
+#					  Valid values: 0 (off) / 1 (on)
+BotLevelBrackets.IgnoreFriendListed = 1	
+
+#
 #    Alliance Level Brackets Configuration
 #    The percentages below must sum to 100.
 #

--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -422,14 +422,17 @@ static bool IsBotSafeForLevelReset(Player* bot)
     }
     // Lets ignore bots that have human friends
     if (g_IgnoreFriendListed)
-    {
+    {        
         QueryResult result = CharacterDatabase.Query("SELECT COUNT(friend) FROM character_social WHERE friend IN (SELECT guid FROM characters WHERE name ='{}') and flags = 1", bot->GetName());
         uint32 friendCount = 0;
-        friendCount = result->Fetch()->Get<uint32>();
-
+        friendCount = result->Fetch()->Get<uint32>();       
+        
         if (friendCount >= 1)
         {
-            LOG_INFO("server.loading", "[BotLevelBrackets] Bot {} (Level {}) is on a Real Player's friends list", bot->GetName(), bot->GetLevel());
+            if (g_BotDistFullDebugMode)
+            {
+                LOG_INFO("server.loading", "[BotLevelBrackets] Bot {} (Level {}) is on a Real Player's friends list", bot->GetName(), bot->GetLevel());
+            }
             return false;
         }
     }

--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -60,6 +60,9 @@ static bool   g_IgnoreFriendListed = true;
 // Real player weight to boost bracket contributions.
 static float g_RealPlayerWeight = 1.0f;
 
+// Array for character social list friends
+std::vector<int> SocialFriendsList;
+
 // -----------------------------------------------------------------------------
 // Loads the configuration from the config file.
 // -----------------------------------------------------------------------------
@@ -104,6 +107,37 @@ static void LoadBotLevelBracketsConfig()
     g_HordeLevelRanges[8] = { 80, 80, static_cast<uint8>(sConfigMgr->GetOption<uint32>("BotLevelBrackets.Horde.Range9Pct", 11)) };
 
     ClampAndBalanceBrackets();
+}
+
+// -----------------------------------------------------------------------------
+// Loads the friend guid(s) from character_social into array
+// ----------------------------------------------------------------------------- 
+static void LoadSocialFriendList()
+{
+    SocialFriendsList.clear();
+    QueryResult result = CharacterDatabase.Query("SELECT friend FROM character_social WHERE flags = 1");
+
+    if (!result)
+        return;
+
+    if (result->GetRowCount() == 0)
+        return;
+
+    if (g_BotDistFullDebugMode)
+    {
+        LOG_INFO("server.loading", "[BotLevelBrackets] Fetching Social Friend List GUIDs into array");
+    }
+
+    do
+    {
+        uint32 socialFriendGUID = result->Fetch()->Get<uint32>();
+        SocialFriendsList.push_back(socialFriendGUID);
+        if (g_BotDistFullDebugMode)
+        {
+            LOG_INFO("server.load", "[BotLevelBrackets] Adding GUID {} to Social Friend List", socialFriendGUID);
+        }
+    } while (result->NextRow());
+
 }
 
 // Returns the index of the level range bracket that the given level belongs to.
@@ -422,18 +456,22 @@ static bool IsBotSafeForLevelReset(Player* bot)
     }
     // Lets ignore bots that have human friends
     if (g_IgnoreFriendListed)
-    {        
-        QueryResult result = CharacterDatabase.Query("SELECT COUNT(friend) FROM character_social WHERE friend IN (SELECT guid FROM characters WHERE name ='{}') and flags = 1", bot->GetName());
-        uint32 friendCount = 0;
-        friendCount = result->Fetch()->Get<uint32>();       
-        
-        if (friendCount >= 1)
+    {   
+        for(auto i = 0; i < SocialFriendsList.size(); i++)      
         {
             if (g_BotDistFullDebugMode)
             {
-                LOG_INFO("server.loading", "[BotLevelBrackets] Bot {} (Level {}) is on a Real Player's friends list", bot->GetName(), bot->GetLevel());
+                LOG_INFO("server.loading", "[BotLevelBrackets] Check bot {} against SocialFriendsList Array Character GUID {}", bot->GetName(), SocialFriendsList[i]);
             }
-            return false;
+
+            if (SocialFriendsList[i] == bot->GetGUID().GetRawValue())
+            {
+                if (g_BotDistFullDebugMode)
+                {
+                    LOG_INFO("server.loading", "[BotLevelBrackets] Bot {} (Level {}) is on a Real Player's friends list", bot->GetName(), bot->GetLevel());
+                }
+                return false;
+            }
         }
     }
 
@@ -557,6 +595,7 @@ public:
     void OnStartup() override
     {
         LoadBotLevelBracketsConfig();
+        LoadSocialFriendList();
         if (!g_BotLevelBracketsEnabled)
         {
             LOG_INFO("server.loading", "[BotLevelBrackets] Module disabled via configuration.");
@@ -582,7 +621,7 @@ public:
     {
         if (!g_BotLevelBracketsEnabled)
             return;
-
+        
         m_timer += diff;
         m_flaggedTimer += diff;
 
@@ -592,7 +631,7 @@ public:
             if (g_BotDistFullDebugMode)
             {
                 LOG_INFO("server.loading", "[BotLevelBrackets] Pending Level Resets Triggering.");
-            }
+            }            
             ProcessPendingLevelResets();
             m_flaggedTimer = 0;
         }
@@ -601,6 +640,9 @@ public:
         if (m_timer < g_BotDistCheckFrequency * 1000)
             return;
         m_timer = 0;
+
+        // Refresh Social Friends List Array
+        LoadSocialFriendList();
 
         // Dynamic distribution: recalc desired percentages based on non-bot players.
         if (g_UseDynamicDistribution)

--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -15,6 +15,9 @@
 #include <limits>
 #include <algorithm>
 #include "PlayerbotFactory.h"
+#include "DatabaseEnv.h"
+#include "QueryResult.h"
+
 
 static bool IsAlliancePlayerBot(Player* bot);
 static bool IsHordePlayerBot(Player* bot);
@@ -52,6 +55,7 @@ static uint32 g_BotDistFlaggedCheckFrequency = 15; // in seconds
 static bool   g_BotDistFullDebugMode      = false;
 static bool   g_BotDistLiteDebugMode      = false;
 static bool   g_UseDynamicDistribution  = false;
+static bool   g_IgnoreFriendListed = true;
 
 // Real player weight to boost bracket contributions.
 static float g_RealPlayerWeight = 1.0f;
@@ -71,6 +75,7 @@ static void LoadBotLevelBracketsConfig()
     g_BotDistFlaggedCheckFrequency = sConfigMgr->GetOption<uint32>("BotLevelBrackets.CheckFlaggedFrequency", 15);
     g_UseDynamicDistribution = sConfigMgr->GetOption<bool>("BotLevelBrackets.UseDynamicDistribution", false);
     g_RealPlayerWeight = sConfigMgr->GetOption<float>("BotLevelBrackets.RealPlayerWeight", 1.0f);
+    g_IgnoreFriendListed = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreFriendListed", true);
 
     // Load the bot level restrictions.
     g_RandomBotMinLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotMinLevel", 1));
@@ -415,6 +420,20 @@ static bool IsBotSafeForLevelReset(Player* bot)
             }
         }
     }
+    // Lets ignore bots that have human friends
+    if (g_IgnoreFriendListed)
+    {
+        QueryResult result = CharacterDatabase.Query("SELECT COUNT(friend) FROM character_social WHERE friend IN (SELECT guid FROM characters WHERE name ='{}') and flags = 1", bot->GetName());
+        uint32 friendCount = 0;
+        friendCount = result->Fetch()->Get<uint32>();
+
+        if (friendCount >= 1)
+        {
+            LOG_INFO("server.loading", "[BotLevelBrackets] Bot {} (Level {}) is on a Real Player's friends list", bot->GetName(), bot->GetLevel());
+            return false;
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Added a check to see if a rndbot is on a friend list, if they are then they will be flagged as not safe for level reset

Kept the SQL query simple, it does not check that the rndbot is on a real players friend list but I don't think rndbots go around friending other bots

Also my C++ is very limited, so not sure if the added #include "DatabaseEnv.h", and #include "QueryResult.h" are necessary