### PR TITLE
Sync Brackets between factions when dynamic distribution is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Features
   When enabled, bots that are on real players' friend lists are excluded from level bracket adjustments.
 - **Dynamic Distribution:**  
   Optionally enable dynamic recalculation of bot distribution percentages based on the number of non-bot players present in each bracket.
+- **Sync Factions Bracket:** 
+  Requires Dynamic Distribution to be on. Optionally enable synchronized bracket and weighting logic between Alliance and Horde. When enabled, both bracket range definitions must match exactly for both factions and real player activity from either faction influences bot bracket distribution for both factions.
 - **Debug Modes:**  
   Full and Lite debug modes provide detailed logging for troubleshooting and monitoring bot adjustments.
 
@@ -76,8 +78,9 @@ BotLevelBrackets.FullDebugMode               | Enables full debug logging for th
 BotLevelBrackets.LiteDebugMode               | Enables lite debug logging for the Bot Level Brackets module.                                                                    | 0       | 0 (off) / 1 (on)
 BotLevelBrackets.CheckFrequency              | Frequency (in seconds) at which the bot level distribution check is performed.                                                  | 300     | Positive Integer
 BotLevelBrackets.CheckFlaggedFrequency       | Frequency (in seconds) at which the bot level reset is performed for flagged bots that initially failed safety checks.             | 15      | Positive Integer
-BotLevelBrackets.UseDynamicDistribution      | Enables dynamic recalculation of bot distribution percentages based on non-bot player counts per bracket.                        | 0       | 0 (off) / 1 (on)
-BotLevelBrackets.RealPlayerWeight            | Multiplier applied to each real player's contribution (active only if dynamic distribution is enabled).                          | 1.0     | Floating point number
+BotLevelBrackets.Dynamic.UseDynamicDistribution      | Enables dynamic recalculation of bot distribution percentages based on non-bot player counts per bracket.                        | 0       | 0 (off) / 1 (on)
+BotLevelBrackets.Dynamic.RealPlayerWeight            | Multiplier applied to each real player's contribution (active only if dynamic distribution is enabled).                          | 1.0     | Floating point number
+BotLevelBrackets.Dynamic.SyncFactions      | Enables synchronized brackets and weighting between Alliance and Horde factions when Dynamic Distribution is also enabled.                        | 0       | 0 (off) / 1 (on)
 BotLevelBrackets.IgnoreFriendListed           | Ignores bots that are on real players' friend lists from any bracket calculations.                                              | 1       | 0 (off) / 1 (on)
 BotLevelBrackets.IgnoreGuildBotsWithRealPlayers | Excludes bots in a guild with at least one real (non-bot) player online from adjustments.                                       | 1       | 0 (disabled) / 1 (enabled)
 BotLevelBrackets.NumRanges                     | Number of level brackets used for bot distribution. Both factions must have the same number defined.                             | 9       | Positive Integer

--- a/conf/mod_player_bot_level_brackets.conf.dist
+++ b/conf/mod_player_bot_level_brackets.conf.dist
@@ -45,22 +45,6 @@ BotLevelBrackets.CheckFlaggedFrequency = 15
 BotLevelBrackets.IgnoreGuildBotsWithRealPlayers = 1
 
 #
-#    BotLevelBrackets.UseDynamicDistribution
-#        Description: Enables dynamic recalculation of bot distribution percentages based on the number of non-bot players 
-#                     present in each level bracket.
-#        Default:     0 (disabled)
-#                     Valid values: 0 (off) / 1 (on)
-BotLevelBrackets.UseDynamicDistribution = 0
-
-#
-#    BotLevelBrackets.RealPlayerWeight
-#        Description: A multiplier applied to each real player's contribution in their level bracket.
-#                     When combined with inverse scaling by total player count, a higher value significantly boosts the effective weight
-#                     of a real player when few are online.
-#        Default:     1.0
-BotLevelBrackets.RealPlayerWeight = 1.0
-
-#
 #    BotLevelBrackets.IgnoreFriendListed
 #         Description: Ignore bots that are on real players friend's lists from any brackets.
 #         Default:     1 (enabled)
@@ -78,6 +62,32 @@ BotLevelBrackets.IgnoreFriendListed = 1
 #            lines for the additional bracket lines added below (e.g. Range10, Range11, etc.). Ensure that the
 #            sum of the Pct values for each faction remains 100.
 BotLevelBrackets.NumRanges = 9
+
+#
+#    BotLevelBrackets.Dynamic.UseDynamicDistribution
+#        Description: Enables dynamic recalculation of bot distribution percentages based on the number of non-bot players 
+#                     present in each level bracket.
+#        Default:     0 (disabled)
+#                     Valid values: 0 (off) / 1 (on)
+BotLevelBrackets.Dynamic.UseDynamicDistribution = 0
+
+#
+#    BotLevelBrackets.Dynamic.RealPlayerWeight
+#        Description: A multiplier applied to each real player's contribution in their level bracket.
+#                     When combined with inverse scaling by total player count, a higher value significantly boosts the effective weight
+#                     of a real player when few are online.
+#        Default:     1.0
+BotLevelBrackets.Dynamic.RealPlayerWeight = 1.0
+
+#
+#    BotLevelBrackets.Dynamic.SyncFactions
+#        Description: If enabled, both Alliance and Horde must have identical bracket definitions (same number, same level bounds).
+#                     All real players (regardless of faction) influence the dynamic distribution for both factions.
+#        Default:     0 (disabled)
+#   Valid values:     0 (off) / 1 (on)
+#        WARNING: Server will fail to start if brackets do not match when enabled.
+#
+BotLevelBrackets.Dynamic.SyncFactions = 0
 
 ##############################################
 # Alliance Level Brackets Configuration


### PR DESCRIPTION
**Sync Factions Bracket:**
Requires Dynamic Distribution to be on. Optionally enable synchronized bracket and weighting logic between Alliance and Horde. When enabled, both bracket range definitions must match exactly for both factions and real player activity from either faction influences bot bracket distribution for both factions.