### PR TITLE
[Enhancement] Throttling the amount of bots adjusted and spreading the process out.

### DIFF
--- a/conf/mod_player_bot_level_brackets.conf.dist
+++ b/conf/mod_player_bot_level_brackets.conf.dist
@@ -32,9 +32,15 @@ BotLevelBrackets.CheckFrequency = 300
 
 #
 #    BotLevelBrackets.CheckFlaggedFrequency
-#        Description: The frequency (in seconds) at which the bot level reset is performed for flagged bots that failed safety checks initially.
-#        Default:     15
+#        Description: The frequency (in seconds) at which the bot level reset is performed for processing safe bots and checking flagged bots that failed safety checks initially.
+#        Default:    15
 BotLevelBrackets.CheckFlaggedFrequency = 15
+
+#    BotLevelBrackets.FlaggedProcessLimit
+#        Description: Maximum number of flagged bots to process per flagged check step.
+#                     0 = unlimited (process all flagged bots each step)
+#        Default:     5
+BotLevelBrackets.FlaggedProcessLimit = 5
 
 #
 #    BotLevelBrackets.IgnoreGuildBotsWithRealPlayers

--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -57,7 +57,7 @@ static bool   g_BotDistFullDebugMode      = false;
 static bool   g_BotDistLiteDebugMode      = false;
 static bool   g_UseDynamicDistribution  = false;
 static bool   g_IgnoreFriendListed = true;
-static uint32 g_FlaggedProcessLimit = 0; // 0 = unlimited
+static uint32 g_FlaggedProcessLimit = 5; // 0 = unlimited
 
 
 // Real player weight to boost bracket contributions.
@@ -87,7 +87,7 @@ static void LoadBotLevelBracketsConfig()
     g_RealPlayerWeight = sConfigMgr->GetOption<float>("BotLevelBrackets.Dynamic.RealPlayerWeight", 1.0f);
     g_SyncFactions = sConfigMgr->GetOption<bool>("BotLevelBrackets.Dynamic.SyncFactions", false);
     g_IgnoreFriendListed = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreFriendListed", true);
-    g_FlaggedProcessLimit = sConfigMgr->GetOption<uint32>("BotLevelBrackets.FlaggedProcessLimit", 0);
+    g_FlaggedProcessLimit = sConfigMgr->GetOption<uint32>("BotLevelBrackets.FlaggedProcessLimit", 5);
 
     // Load the bot level restrictions.
     g_RandomBotMinLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotMinLevel", 1));
@@ -1008,7 +1008,6 @@ public:
                         LOG_INFO("server.loading", "[BotLevelBrackets] !!!! Adjusting alliance bot '{}' from range {} to range {} ({}-{}).",  
                                  bot->GetName(), i + 1, targetRange + 1, g_AllianceLevelRanges[targetRange].lower, g_AllianceLevelRanges[targetRange].upper);
                     }
-                    //AdjustBotToRange(bot, targetRange, g_AllianceLevelRanges.data());
                     bool alreadyFlagged = false;
                     for (auto& entry : g_PendingLevelResets)
                     {
@@ -1177,7 +1176,6 @@ public:
                         LOG_INFO("server.loading", "[BotLevelBrackets] !!!! Adjusting horde bot '{}' from range {} to range {} ({}-{}).", 
                                  bot->GetName(), i + 1, targetRange + 1, g_HordeLevelRanges[targetRange].lower, g_HordeLevelRanges[targetRange].upper);
                     }
-                    //AdjustBotToRange(bot, targetRange, g_HordeLevelRanges.data());
                     bool alreadyFlagged = false;
                     for (auto& entry : g_PendingLevelResets)
                     {


### PR DESCRIPTION
Adding new config option and setting default performance mode, uses the pending reset system to process X number of bots based on the config each X seconds instead of just doing one big update batch, locking the server up for 10's of seconds at a time.