### PR TITLE
Exclusion list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ BotLevelBrackets.Dynamic.SyncFactions      | Enables synchronized brackets and w
 BotLevelBrackets.IgnoreFriendListed           | Ignores bots that are on real players' friend lists from any bracket calculations.                                              | 1       | 0 (off) / 1 (on)
 BotLevelBrackets.IgnoreGuildBotsWithRealPlayers | Excludes bots in a guild with at least one real (non-bot) player online from adjustments.                                       | 1       | 0 (disabled) / 1 (enabled)
 BotLevelBrackets.NumRanges                     | Number of level brackets used for bot distribution. Both factions must have the same number defined.                             | 9       | Positive Integer
+BotLevelBrackets.ExcludeNames                  | Comma-separated list of case insensitive bot names to exclude from all bracket checks.                                                            |         | String
 
 **IMPORTANT:** If you extend the number of brackets beyond the default 9, you must update both your `mod_player_bot_level_brackets.conf` file and the accompanying `mod_player_bot_level_brackets.conf.dist` file to include configuration lines for the additional ranges (e.g. Range10, Range11, etc.), ensuring that the sum of the Pct values remains 100.
 

--- a/conf/mod_player_bot_level_brackets.conf.dist
+++ b/conf/mod_player_bot_level_brackets.conf.dist
@@ -57,6 +57,11 @@ BotLevelBrackets.IgnoreGuildBotsWithRealPlayers = 1
 #                      Valid values: 0 (off) / 1 (on)
 BotLevelBrackets.IgnoreFriendListed = 1
 
+# BotLevelBrackets.ExcludeNames
+#     Description: Comma-separated list of case insensitive bot names to exclude from all bracket checks.
+#     Default:     ""
+BotLevelBrackets.ExcludeNames =
+
 #
 #    BotLevelBrackets.NumRanges
 #        Description: The number of level brackets used for bot distribution.


### PR DESCRIPTION
## Pull Request: Add Bot Name Exclusion Feature for Player Bot Level Brackets

### Summary
This PR adds a configurable exclusion system for player bot level bracket processing. Any bot whose name is included in the new exclusion list will be ignored for all bracket checks and level resets.

---

### Features / Changes

- **Configuration Option**
  - `BotLevelBrackets.ExcludeNames`: Comma-separated list of bot names to exclude from bracket logic.
    - Example:  
      `BotLevelBrackets.ExcludeNames = TestBot1,MySpecialBot,devbot`
  - Located in your mod's `.conf.dist` file.

- **Case-Insensitive Matching**
  - Name matching is case-insensitive, reflecting actual World of Warcraft name handling.
  - 
- **Integration Points**
  - **OnUpdate() player loop:** Excluded bots are skipped immediately after the bot type check.
  - **ProcessPendingLevelResets():** Excluded bots are removed from the pending list after session/world checks.
  - **GetOrFlagPlayerBracket():** Excluded bots are never flagged or processed for bracket logic.
  - All code locations are documented in the AzerothCore style with full block comments.

---

### Example Configuration

```ini
# Comma-separated list of bot names to exclude from bracket processing
BotLevelBrackets.ExcludeNames = TestBot1,AnotherBot,SomeDevBot
