### PR TITLE
Fixed talents not reseting correctly

### DIFF
--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -671,6 +671,8 @@ static void AdjustBotToRange(Player* bot, int targetRangeIndex, const LevelRange
         newLevel = GetRandomLevelInRange(factionRanges[targetRangeIndex]);
     }
 
+    bot->resetTalents(true);
+
     PlayerbotFactory newFactory(bot, newLevel);
     newFactory.Randomize(false);
 


### PR DESCRIPTION
Fixes #67 

This issue is resolved by adding a talent reset to the bots talents before calling PlayerbotFactory::Randomize().

If equipment persistence is enabled and the bot gets rolled to ≥ equipment persistence level then the bot will not get its talents reset and this issue #67 will result. I cant think of a situation where you would not want a bot to have its talents reset when it is re-rolled regardless of equipment persistence being enabled.

This PR makes it so bot talents are ALWAYS reset when bots are re-rolled regardless if equipment persistence is enabled.

<img width="919" height="378" alt="image" src="https://github.com/user-attachments/assets/5638be07-4e18-43d5-b6bf-cea13c5a5cd6" />


Testing:
- I tested this by setting all the bots to level 30 and then letting the mod re-balance them all to 60 and back the other way and observed no more issues with messed up talent trees with the settings below.

`
AiPlayerbot.EquipmentPersistence = 1`

`AiPlayerbot.EquipmentPersistenceLevel = 60`