### PR TITLE
Dustin/bug fixes

### DIFF
--- a/conf/mod_player_bot_level_brackets.conf.dist
+++ b/conf/mod_player_bot_level_brackets.conf.dist
@@ -52,6 +52,15 @@ BotLevelBrackets.FlaggedProcessLimit = 5
 BotLevelBrackets.IgnoreGuildBotsWithRealPlayers = 1
 
 #
+#    BotLevelBrackets.IgnoreArenaTeamBots
+#        Description: When enabled, bots that are members of arena teams are excluded from bot bracket calculations
+#                     and will not be level changed or flagged. This prevents bots in arena teams from being
+#                     changed, which would break team compositions.
+#        Default:     1 (enabled)
+#                     Valid values: 0 (disabled) / 1 (enabled)
+BotLevelBrackets.IgnoreArenaTeamBots = 1
+
+#
 #    BotLevelBrackets.GuildTrackerUpdateFrequency
 #        Description: The frequency (in seconds) at which the persistent guild tracker database is updated.
 #                     This tracks which guilds have real players even when they are offline.

--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include "Player.h"
 #include "PlayerbotAIConfig.h"
+#include "ArenaTeamMgr.h"
 
 using namespace Acore::ChatCommands;
 
@@ -52,6 +53,8 @@ static uint8 g_RandomBotMaxLevel = 80;
 static bool g_BotLevelBracketsEnabled = true;
 // Ignore bots in guilds with a real player online. Default is true.
 static bool g_IgnoreGuildBotsWithRealPlayers = true;
+// Ignore bots in arena teams. Default is true.
+static bool g_IgnoreArenaTeamBots = true;
 
 // Use vectors to store the level ranges.
 static std::vector<LevelRangeConfig> g_AllianceLevelRanges;
@@ -112,6 +115,7 @@ static void LoadBotLevelBracketsConfig()
 {
     g_BotLevelBracketsEnabled = sConfigMgr->GetOption<bool>("BotLevelBrackets.Enabled", true);
     g_IgnoreGuildBotsWithRealPlayers = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreGuildBotsWithRealPlayers", true);
+    g_IgnoreArenaTeamBots = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreArenaTeamBots", true);
     
     g_BotDistFullDebugMode = sConfigMgr->GetOption<bool>("BotLevelBrackets.FullDebugMode", false);
     g_BotDistLiteDebugMode = sConfigMgr->GetOption<bool>("BotLevelBrackets.LiteDebugMode", false);
@@ -745,6 +749,30 @@ static bool BotInFriendList(Player* bot)
 
 
 /**
+ * @brief Checks if the given bot is a member of any arena team.
+ *
+ * This function verifies that the provided Player pointer is valid and
+ * checks all arena team slots to see if the bot is in any arena team.
+ *
+ * @param bot Pointer to the Player object representing the bot.
+ * @return true if the bot is in an arena team, false otherwise.
+ */
+static bool BotInArenaTeam(Player* bot)
+{
+    if (!bot)
+        return false;
+    for (uint32 slot = 0; slot < MAX_ARENA_SLOT; ++slot)
+    {
+        if (ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(bot->GetArenaTeamId(slot)))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+/**
  * @brief Clamps and balances the level brackets for Alliance and Horde bot distributions.
  *
  * This function ensures that the lower and upper bounds of each level bracket for both Alliance and Horde
@@ -1023,6 +1051,12 @@ static void ProcessPendingLevelResets()
                 continue;
             }
 
+            if (g_IgnoreArenaTeamBots && BotInArenaTeam(bot))
+            {
+                it = g_PendingLevelResets.erase(it);
+                continue;
+            }
+
             if (bot && bot->IsInWorld() && IsBotSafeForLevelReset(bot))
             {
                 AdjustBotToRange(bot, targetRange, it->factionRanges);
@@ -1054,6 +1088,16 @@ static void ProcessPendingLevelResets()
 static int GetOrFlagPlayerBracket(Player* player)
 {
     if (IsPlayerBot(player) && IsBotExcluded(player))
+    {
+        return -1;
+    }
+
+    if (IsPlayerBot(player) && g_IgnoreGuildBotsWithRealPlayers && BotInGuildWithRealPlayer(player))
+    {
+        return -1;
+    }
+
+    if (IsPlayerBot(player) && g_IgnoreArenaTeamBots && BotInArenaTeam(player))
     {
         return -1;
     }
@@ -1427,6 +1471,10 @@ public:
                 continue;
             }
             if (g_IgnoreFriendListed && BotInFriendList(player))
+            {
+                continue;
+            }
+            if (g_IgnoreArenaTeamBots && BotInArenaTeam(player))
             {
                 continue;
             }


### PR DESCRIPTION
This pull request introduces a new configuration option to exclude bots that are members of arena teams from bot bracket calculations and related level changes. This helps prevent issues with team compositions in arena teams. The changes include updates to both configuration files and logic in the implementation to respect this new setting.

### Configuration changes

* Added `BotLevelBrackets.IgnoreArenaTeamBots` option to `conf/mod_player_bot_level_brackets.conf.dist`, allowing admins to control whether bots in arena teams are excluded from bracket calculations and level changes.

### Implementation changes

* Introduced a new global flag `g_IgnoreArenaTeamBots` and loaded its value from the configuration file in the `LoadBotLevelBracketsConfig()` function. [[1]](diffhunk://#diff-66f94da0afd66f12c0f7689952cbfd68c33582bb230a32aeb74949398502a162R56-R57) [[2]](diffhunk://#diff-66f94da0afd66f12c0f7689952cbfd68c33582bb230a32aeb74949398502a162R118)
* Added the `BotInArenaTeam(Player* bot)` helper function to check if a bot is a member of any arena team.

### Logic updates

* Updated `ProcessPendingLevelResets()` and `GetOrFlagPlayerBracket()` to skip bots that are in arena teams when the new configuration flag is enabled, preventing level changes and bracket assignments for those bots. [[1]](diffhunk://#diff-66f94da0afd66f12c0f7689952cbfd68c33582bb230a32aeb74949398502a162R1054-R1059) [[2]](diffhunk://#diff-66f94da0afd66f12c0f7689952cbfd68c33582bb230a32aeb74949398502a162R1095-R1104)
* Modified world script logic to exclude bots in arena teams from certain calculations when the flag is enabled.

### Bug fixes

* Fixed an issue in `AdjustBotToRange()` to reset talents for bots that reach max level when equipment persistence is enabled, addressing randomization problems.