### PR TITLE
Fixing a DK edgecase

### DIFF
--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -1130,6 +1130,13 @@ static int GetOrFlagPlayerBracket(Player* player)
         {
             continue;
         }
+        
+        // Skip brackets that Death Knights cannot be assigned to (upper bound < 55)
+        if (player->getClass() == CLASS_DEATH_KNIGHT && factionRanges[i].upper < 55)
+        {
+            continue;
+        }
+        
         int diff = 0;
         if (player->GetLevel() < factionRanges[i].lower)
         {


### PR DESCRIPTION
Added a check in GetOrFlagPlayerBracket() to skip brackets with upper < 55 when selecting a target bracket for Death Knight bots. This prevents DKs from ever being flagged for impossible resets.