### PR TITLE
Update for pending breaking change from playerbots

### DIFF
--- a/src/mod-player-bot-level-brackets.cpp
+++ b/src/mod-player-bot-level-brackets.cpp
@@ -116,7 +116,7 @@ static void LoadBotLevelBracketsConfig()
     g_BotLevelBracketsEnabled = sConfigMgr->GetOption<bool>("BotLevelBrackets.Enabled", true);
     g_IgnoreGuildBotsWithRealPlayers = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreGuildBotsWithRealPlayers", true);
     g_IgnoreArenaTeamBots = sConfigMgr->GetOption<bool>("BotLevelBrackets.IgnoreArenaTeamBots", true);
-    
+
     g_BotDistFullDebugMode = sConfigMgr->GetOption<bool>("BotLevelBrackets.FullDebugMode", false);
     g_BotDistLiteDebugMode = sConfigMgr->GetOption<bool>("BotLevelBrackets.LiteDebugMode", false);
     g_BotDistCheckFrequency = sConfigMgr->GetOption<uint32>("BotLevelBrackets.CheckFrequency", 300);
@@ -175,8 +175,8 @@ static void LoadBotLevelBracketsConfig()
                 LOG_ERROR("server.loading", "[BotLevelBrackets] FATAL: Bracket mismatch detected between factions at index {}. "
                     "Alliance: {}-{}, Horde: {}-{}. "
                     "When SyncFactions is enabled, both bracket number and min/max levels must match exactly. "
-                    "Check your configuration.", 
-                    i, g_AllianceLevelRanges[i].lower, g_AllianceLevelRanges[i].upper, 
+                    "Check your configuration.",
+                    i, g_AllianceLevelRanges[i].lower, g_AllianceLevelRanges[i].upper,
                     g_HordeLevelRanges[i].lower, g_HordeLevelRanges[i].upper);
                 std::terminate();
             }
@@ -333,7 +333,7 @@ static void LoadPersistentGuildTracker()
 {
     g_PersistentRealPlayerGuildIds.clear();
     QueryResult result = CharacterDatabase.Query("SELECT guild_id FROM bot_level_brackets_guild_tracker WHERE has_real_players = 1");
-    
+
     if (!result)
     {
         if (g_BotDistFullDebugMode)
@@ -342,12 +342,12 @@ static void LoadPersistentGuildTracker()
         }
         return;
     }
-    
+
     if (g_BotDistFullDebugMode)
     {
         LOG_INFO("server.loading", "[BotLevelBrackets] Loading persistent guild tracker data from database...");
     }
-    
+
     do
     {
         uint32 guildId = result->Fetch()->Get<uint32>();
@@ -357,7 +357,7 @@ static void LoadPersistentGuildTracker()
             LOG_INFO("server.loading", "[BotLevelBrackets] Loaded guild {} as having real players.", guildId);
         }
     } while (result->NextRow());
-    
+
     if (g_BotDistFullDebugMode || g_BotDistLiteDebugMode)
     {
         LOG_INFO("server.loading", "[BotLevelBrackets] Loaded {} guilds with real players from persistent storage.", g_PersistentRealPlayerGuildIds.size());
@@ -378,17 +378,17 @@ static void UpdatePersistentGuildTracker()
     {
         LOG_INFO("server.loading", "[BotLevelBrackets] Starting additive-only persistent guild tracker update...");
     }
-    
+
     // Find guilds with currently online real players
     std::unordered_set<uint32> currentRealPlayerGuilds;
-    
+
     const auto& allPlayers = ObjectAccessor::GetPlayers();
     for (const auto& itr : allPlayers)
     {
         Player* player = itr.second;
         if (!player || !player->IsInWorld())
             continue;
-            
+
         if (!IsPlayerBot(player))
         {
             uint32 guildId = player->GetGuildId();
@@ -398,9 +398,9 @@ static void UpdatePersistentGuildTracker()
             }
         }
     }
-    
+
     uint32 addedCount = 0;
-    
+
     // Update or insert guilds with real players - ensure has_real_players is set to 1
     for (uint32 guildId : currentRealPlayerGuilds)
     {
@@ -410,15 +410,15 @@ static void UpdatePersistentGuildTracker()
             "VALUES ({}, 1)",
             guildId
         );
-        
+
         // Add to our in-memory cache
         g_PersistentRealPlayerGuildIds.insert(guildId);
         addedCount++;
     }
-    
+
     if (g_BotDistFullDebugMode || g_BotDistLiteDebugMode)
     {
-        LOG_INFO("server.loading", "[BotLevelBrackets] Additive guild tracker update complete. {} guilds processed, {} total tracked guilds.", 
+        LOG_INFO("server.loading", "[BotLevelBrackets] Additive guild tracker update complete. {} guilds processed, {} total tracked guilds.",
                  addedCount, g_PersistentRealPlayerGuildIds.size());
     }
 }
@@ -437,7 +437,7 @@ static void CleanupGuildTracker()
     {
         LOG_INFO("server.loading", "[BotLevelBrackets] Starting guild tracker cleanup - removing guilds with no online real players...");
     }
-    
+
     // Get current guilds with online real players
     std::unordered_set<uint32> currentRealPlayerGuilds;
     const auto& allPlayers = ObjectAccessor::GetPlayers();
@@ -446,7 +446,7 @@ static void CleanupGuildTracker()
         Player* player = itr.second;
         if (!player || !player->IsInWorld())
             continue;
-            
+
         if (!IsPlayerBot(player))
         {
             uint32 guildId = player->GetGuildId();
@@ -456,7 +456,7 @@ static void CleanupGuildTracker()
             }
         }
     }
-    
+
     // Find guilds to remove (those in tracker but not in current real player guilds)
     std::vector<uint32> guildsToRemove;
     for (uint32 trackedGuildId : g_PersistentRealPlayerGuildIds)
@@ -466,7 +466,7 @@ static void CleanupGuildTracker()
             guildsToRemove.push_back(trackedGuildId);
         }
     }
-    
+
     // Remove guilds that no longer have real players online
     uint32 removedCount = 0;
     for (uint32 guildId : guildsToRemove)
@@ -476,21 +476,21 @@ static void CleanupGuildTracker()
             "UPDATE bot_level_brackets_guild_tracker SET has_real_players = 0 WHERE guild_id = {}",
             guildId
         );
-        
+
         // Remove from in-memory caches
         g_PersistentRealPlayerGuildIds.erase(guildId);
         g_RealPlayerGuildIds.erase(guildId);
         removedCount++;
-        
+
         if (g_BotDistFullDebugMode)
         {
             LOG_INFO("server.loading", "[BotLevelBrackets] Removed guild {} from tracker - no real players online.", guildId);
         }
     }
-    
+
     if (g_BotDistFullDebugMode || g_BotDistLiteDebugMode)
     {
-        LOG_INFO("server.loading", "[BotLevelBrackets] Guild tracker cleanup complete. {} guilds removed, {} guilds remain.", 
+        LOG_INFO("server.loading", "[BotLevelBrackets] Guild tracker cleanup complete. {} guilds removed, {} guilds remain.",
                  removedCount, g_PersistentRealPlayerGuildIds.size());
     }
 }
@@ -605,7 +605,7 @@ static void AdjustBotToRange(Player* bot, int targetRangeIndex, const LevelRange
     {
         return;
     }
-    
+
     if (targetRangeIndex < 0 || targetRangeIndex >= g_NumRanges)
     {
         return;
@@ -665,9 +665,9 @@ static void AdjustBotToRange(Player* bot, int targetRangeIndex, const LevelRange
     PlayerbotFactory newFactory(bot, newLevel);
     newFactory.Randomize(false);
 
-    // Force reset talents if equipment persistence is enabled and bot rolled to max level
-    // This is to fix an issue with Playerbots and how Randomization works with Equipment Persistence
-    if (newLevel == g_RandomBotMaxLevel && sPlayerbotAIConfig.equipmentPersistence)
+    // Force reset talents if equipment and spec persistence is enabled and bot rolled to max level
+    // This is to fix an issue with Playerbots and how randomization works with equipment and spec persistence
+    if (newLevel == g_RandomBotMaxLevel && sPlayerbotAIConfig.equipAndSpecPersistence)
     {
         PlayerbotFactory tempFactory(bot, newLevel);
         tempFactory.InitTalentsTree(false, true, true);
@@ -1019,7 +1019,7 @@ static void ProcessPendingLevelResets()
                 break;
 
             Player* bot = ObjectAccessor::FindPlayer(it->botGuid);
-            
+
             if (!bot)
             {
                 it = g_PendingLevelResets.erase(it);
@@ -1134,7 +1134,7 @@ static int GetOrFlagPlayerBracket(Player* player)
                 {
                     if (g_BotDistFullDebugMode)
                     {
-                        LOG_INFO("server.loading", "[BotLevelBrackets] GetOrFlagPlayerBracket: Bot {} (Level {}) is in group with real player {} - excluding from bracket processing.", 
+                        LOG_INFO("server.loading", "[BotLevelBrackets] GetOrFlagPlayerBracket: Bot {} (Level {}) is in group with real player {} - excluding from bracket processing.",
                                  player->GetName(), player->GetLevel(), member->GetName());
                     }
                     return -1;
@@ -1171,13 +1171,13 @@ static int GetOrFlagPlayerBracket(Player* player)
         {
             continue;
         }
-        
+
         // Skip brackets that Death Knights cannot be assigned to (upper bound < 55)
         if (player->getClass() == CLASS_DEATH_KNIGHT && factionRanges[i].upper < 55)
         {
             continue;
         }
-        
+
         int diff = 0;
         if (player->GetLevel() < factionRanges[i].lower)
         {
@@ -1314,7 +1314,7 @@ public:
         {
             return;
         }
-        
+
         m_timer += diff;
         m_flaggedTimer += diff;
         m_guildTrackerTimer += diff;
@@ -1465,7 +1465,7 @@ public:
                 }
             }
         }
-        
+
         uint32 totalAllianceBots = 0;
         std::vector<int> allianceActualCounts(g_NumRanges, 0);
         std::vector< std::vector<Player*> > allianceBotsByRange(g_NumRanges);
@@ -1536,7 +1536,7 @@ public:
                     allianceBotsByRange[rangeIndex].push_back(player);
                     if (g_BotDistFullDebugMode)
                     {
-                        LOG_INFO("server.loading", "[BotLevelBrackets] Alliance bot '{}' with level {} added to range {}.", 
+                        LOG_INFO("server.loading", "[BotLevelBrackets] Alliance bot '{}' with level {} added to range {}.",
                                  player->GetName(), player->GetLevel(), rangeIndex + 1);
                     }
                 }
@@ -1555,7 +1555,7 @@ public:
                     hordeBotsByRange[rangeIndex].push_back(player);
                     if (g_BotDistFullDebugMode)
                     {
-                        LOG_INFO("server.loading", "[BotLevelBrackets] Horde bot '{}' with level {} added to range {}.", 
+                        LOG_INFO("server.loading", "[BotLevelBrackets] Horde bot '{}' with level {} added to range {}.",
                                  player->GetName(), player->GetLevel(), rangeIndex + 1);
                     }
                 }
@@ -1587,7 +1587,7 @@ public:
                 allianceDesiredCounts[i] = static_cast<int>(round((g_AllianceLevelRanges[i].desiredPercent / 100.0) * totalAllianceBots));
                 if (g_BotDistFullDebugMode || g_BotDistLiteDebugMode)
                 {
-                    LOG_INFO("server.loading", "[BotLevelBrackets] Alliance Range {} ({}-{}): Desired = {}, Actual = {}.", 
+                    LOG_INFO("server.loading", "[BotLevelBrackets] Alliance Range {} ({}-{}): Desired = {}, Actual = {}.",
                             i + 1, g_AllianceLevelRanges[i].lower, g_AllianceLevelRanges[i].upper,
                             allianceDesiredCounts[i], allianceActualCounts[i]);
                 }
@@ -1646,7 +1646,7 @@ public:
                         g_PendingLevelResets.push_back({bot->GetGUID(), targetRange, g_AllianceLevelRanges.data()});
                         if (g_BotDistFullDebugMode)
                         {
-                            LOG_INFO("server.loading", "[BotLevelBrackets] Alliance bot '{}' flagged for pending level reset to range {}-{}.", 
+                            LOG_INFO("server.loading", "[BotLevelBrackets] Alliance bot '{}' flagged for pending level reset to range {}-{}.",
                                 bot->GetName(), g_AllianceLevelRanges[targetRange].lower, g_AllianceLevelRanges[targetRange].upper);
                         }
                     }
@@ -1686,7 +1686,7 @@ public:
                         g_PendingLevelResets.push_back({bot->GetGUID(), targetRange, g_AllianceLevelRanges.data()});
                         if (g_BotDistFullDebugMode)
                         {
-                            LOG_INFO("server.loading", "[BotLevelBrackets] Alliance flagged bot '{}' flagged for pending level reset to range {}-{}.", 
+                            LOG_INFO("server.loading", "[BotLevelBrackets] Alliance flagged bot '{}' flagged for pending level reset to range {}-{}.",
                                 bot->GetName(), g_AllianceLevelRanges[targetRange].lower, g_AllianceLevelRanges[targetRange].upper);
                         }
                     }
@@ -1767,7 +1767,7 @@ public:
                         g_PendingLevelResets.push_back({bot->GetGUID(), targetRange, g_HordeLevelRanges.data()});
                         if (g_BotDistFullDebugMode)
                         {
-                            LOG_INFO("server.loading", "[BotLevelBrackets] Horde bot '{}' flagged for pending level reset to range {}-{}.", 
+                            LOG_INFO("server.loading", "[BotLevelBrackets] Horde bot '{}' flagged for pending level reset to range {}-{}.",
                                 bot->GetName(), g_HordeLevelRanges[targetRange].lower, g_HordeLevelRanges[targetRange].upper);
                         }
                     }
@@ -1806,7 +1806,7 @@ public:
                         g_PendingLevelResets.push_back({bot->GetGUID(), targetRange, g_HordeLevelRanges.data()});
                         if (g_BotDistFullDebugMode)
                         {
-                            LOG_INFO("server.loading", "[BotLevelBrackets] Horde flagged bot '{}' flagged for pending level reset to range {}-{}.", 
+                            LOG_INFO("server.loading", "[BotLevelBrackets] Horde flagged bot '{}' flagged for pending level reset to range {}-{}.",
                                 bot->GetName(), g_HordeLevelRanges[targetRange].lower, g_HordeLevelRanges[targetRange].upper);
                         }
                     }
@@ -1829,7 +1829,7 @@ public:
             for (int i = 0; i < g_NumRanges; ++i)
             {
                 allianceDesiredCounts[i] = static_cast<int>(round((g_AllianceLevelRanges[i].desiredPercent / 100.0) * totalAllianceBots));
-                LOG_INFO("server.loading", "[BotLevelBrackets] Alliance Range {} ({}-{}): Desired = {}, Actual = {}.", 
+                LOG_INFO("server.loading", "[BotLevelBrackets] Alliance Range {} ({}-{}): Desired = {}, Actual = {}.",
                          i + 1, g_AllianceLevelRanges[i].lower, g_AllianceLevelRanges[i].upper,
                          allianceDesiredCounts[i], allianceActualCounts[i]);
             }
@@ -1861,7 +1861,7 @@ public:
         {
             return;
         }
-        
+
         CleanupGuildTracker();
     }
 


### PR DESCRIPTION
I have a playerbots PR that overhauls some of the equipment-randomization-related config options. One thing it does is rename equipmentPersistence to equipAndSpecPersistence to accurately reflect what the config actually does. There is no change in the behavior of it (other than to set default to be enabled instead of disabled).

This PR is to resolve the breaking change. Since playerbots PRs are merged into the test-staging branch for a week first, anybody who uses this mod will need to update if they use test-staging for playerbots, but they should not update yet if they use master.

Please feel free to make any edits. I'm sure it is also possible to allow the mod to accept either config option from playerbots, but since this is just for a week, I figured no need to complicate it.